### PR TITLE
Use the token vs. string distinction for the null policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For more on the policy format, see [the dedicated document](./policy-format.md).
 Browsers then fetch and cache origin policies for a given origin. They can optionally do so proactively (e.g. for frequently-visited origins), but generally will be driven by the web application sending a HTTP response header requesting that a given origin policy be fetched and applied:
 
 ```
-Origin-Policy: allowed=(none my-policy my-old-policy), preferred=my-policy
+Origin-Policy: allowed=(null "my-policy" "my-old-policy"), preferred="my-policy"
 ```
 
 Here the header specifies allowed and preferred policies, which correspond to the JSON document's `"id"` value. This allows servers to take on a variety of behaviors, including:


### PR DESCRIPTION
The structured headers specification provides a distinction between unquoted tokens, and quoted strings. We can leverage that distinction by saying that no policy is indicated via a special token, whereas policy IDs are indicated via strings. This avoids the awkward reserving of a single string as special. For example we no longer need to treat "id": "none" in the JSON as a parse error, because the string "none" is no longer overlapping with the token space.

Additionally, this updates the token to be null, instead of none, since it is natural to talk about the null origin policy.

Note that all the examples previously did not quote policy names, so it appears we were unintentionally using tokens for them. This was simply because I was unaware that strings were supposed to be quoted, and that the string/token distinction existed. It makes sense for the policy names to be strings, not tokens, and this commit updates the examples accordingly.