### PR TITLE
Meta: consolidate anchors blocks in the spec source

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -21,15 +21,6 @@ Markup Shorthands: css no
 !Participate: <a href="https://github.com/WICG/origin-policy">GitHub WICG/origin-policy</a> (<a href="https://github.com/WICG/origin-policy/issues/new">new issue</a>, <a href="https://github.com/WICG/origin-policy/issues?state=open">open issues</a>)
 </pre>
 
-<pre class="anchors">
-spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
-  type: http-header
-    text: Strict-Transport-Security; url: section-6.1
-spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
-  type: http-header
-    text: Vary; url: section-7.1.4
-</pre>
-
 <pre class="biblio">
 {
   "STRUCTURED-HEADERS": {
@@ -77,6 +68,12 @@ spec: FEATURE-POLICY; type: dfn; urlPrefix: https://w3c.github.io/webappsec-feat
   text: create a feature policy for a browsing context; url: create-for-browsingcontext
 spec: CSP; type: dfn; urlPrefix: https://w3c.github.io/webappsec-csp/
   text: set response's CSP list; url: set-response-csp-list
+spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
+  type: http-header
+    text: Strict-Transport-Security; url: section-6.1
+spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
+  type: http-header
+    text: Vary; url: section-7.1.4
 </pre>
 
 <h2 id="intro">Introduction</h2>


### PR DESCRIPTION
I randomly noticed this while reading the source. This should have no observable effect.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/pull/71.html" title="Last updated on Jan 30, 2020, 7:30 PM UTC (46e2e86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/71/3279c1d...46e2e86.html" title="Last updated on Jan 30, 2020, 7:30 PM UTC (46e2e86)">Diff</a>