### PR TITLE
Add latest and latest-from-network tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,20 +68,44 @@ For more on the policy format, see [the dedicated document](./policy-format.md).
 
 ### Fetching and applying the origin policy
 
-Browsers then fetch and cache origin policies for a given origin. They can optionally do so proactively (e.g. for frequently-visited origins), but generally will be driven by the web application sending a HTTP response header requesting that a given origin policy be fetched and applied:
+Browsers then fetch and cache origin policies for a given origin. They can optionally do so proactively (e.g. for frequently-visited origins), but generally will be driven by the web application sending a HTTP response header requesting that a given origin policy be fetched and applied.
+
+For more on the model for fetching and updating origin policies, including motivations behind the design, see [the dedicated document](./version-negotiation.md). Here we summarize the most common patterns applications will probably use:
+
+#### Optional-but-suggested policy
 
 ```
-Origin-Policy: allowed=(null "my-policy" "my-old-policy"), preferred="my-policy"
+Origin-Policy: preferred="my-policy", allowed=("my-old-policy" null)
 ```
 
-Here the header specifies allowed and preferred policies, which are matched against the JSON document's `"ids"` values. This allows servers to take on a variety of behaviors, including:
+This allows a previous revision of the policy (identified by `"my-old-policy"`), or no policy at all (`null`), but specifies that the `"my-policy"` revision is preferred. This response might be processed with the old or null origin policy if those are in the HTTP cache, but in that case, the browser will perform an asynchronous update to fetch the latest policy for use with future responses.
 
-* Require that a given origin policy be available (either from the cache or via fetching) and applied, before proceeding with page initialization
-* Allow a previous revision of the policy, or no policy at all, to apply, but in the background do an asynchronous update of the policy so that future resource fetches will apply the preferred one.
+If a _different_ origin policy is found in the HTTP cache, apart from `"my-policy"` or `"my-old-policy"`, then the response will use the null origin policy, since that is allowed.
 
-For more on the model for fetching and updating origin policies, see [the dedicated document](./version-negotiation.md).
+#### Latest available policy, if any
 
-Another important note is that the policy items in question automatically stop applying (in a policy item-specific way) when the origin policy stops applying. So, for example, removing the `"content_security"` member of the origin policy manifest above would cause any future loads that use that origin policy to not include the CSP in question. Combined with the usual HTTP cache expiry mechanisms for the `/.well-known/origin-policy` resource, this allows a general "max age" mechanism for origin-wide configuration, similar to the `max-age` parameter of [HSTS](https://tools.ietf.org/html/rfc6797), but for all policy items.
+```
+Origin-Policy: preferred=latest-from-network, allowed=(latest null)
+```
+
+This says that any cached origin policy from `/.well-known/origin-policy` can be used, but if no such policy is cached, then the null policy will be used instead. In either case, the latest policy will be fetched asynchronously.
+
+This is essentially a simplification of the previous version, where the server operator is expressing fewer constraints on the exact contents of the policy.
+
+
+#### Mandatory policy
+
+```
+Origin-Policy: allowed=("my-policy")
+```
+
+This says that the only origin policy that is allowed is one identified by `"my-policy"`. The origin policy must be fetched, from the cache or network, and must have an `"ids"` value that contains `"my-policy"`, before the response can be processed. If such an origin policy cannot be found, then the response will be treated as a network error.
+
+This makes the most sense if the origin policy contains security-critical policies which would not be acceptable to continue without.
+
+### Policy expiry
+
+Policy items in question automatically stop applying (in a policy item-specific way) when the origin policy stops applying. So, for example, removing the `"content_security"` member of the origin policy manifest above would cause any future loads that use that origin policy to not include the CSP in question. Combined with the usual HTTP cache expiry mechanisms for the `/.well-known/origin-policy` resource, this allows a general "max age" mechanism for origin-wide configuration, similar to the `max-age` parameter of [HSTS](https://tools.ietf.org/html/rfc6797), but for all policy items.
 
 ### Configurable policy items
 

--- a/index.src.html
+++ b/index.src.html
@@ -208,7 +208,7 @@ This document introduces a new delivery mechanism for policies which are meant t
   Then, change the `<a http-header><code>Origin-Policy</code></a>` response header to indicate that this new policy is preferred:
 
   <pre>
-  <a http-header>Origin-Policy</a>: allowed=("policy-1" "policy-2"), preferred="policy-2"
+  <a http-header>Origin-Policy</a>: preferred="policy-2", allowed=("policy-1")
   </pre>
 
   When the browser sees this header value on any response from <code>https://example.com</code>, one of three things will happen:
@@ -260,6 +260,34 @@ This document introduces a new delivery mechanism for policies which are meant t
   The general rule here is that when adding a new value to the "<code><a for="origin policy manifest">ids</a></code>" field of their origin policy manifest, server operators will be best served by keeping any previous [=origin policy/IDs=] as well, at least until any cached resources that reference that origin policy could have expired.
 </div>
 
+<div class="example" id="example-null">
+  MegaCorp has noticed that first-time visitors to their site, as in <a href="#example-initial-policy">the example above</a>, are having a suboptimal experience, with their responses being blocked by an additional round-trip to fetch the origin policy. Upon reflection, MegaCorp realizes that first-time visitors probably don't need origin policies applied. All of their site's exciting stuff is hidden behind a login wall, which involves at least one navigation. So it would be fine to omit the origin policy for such initial responses, as long as it gets applied on post-login responses.
+
+  To express this, MegaCorp modifies their response header to
+
+  <pre>
+  <a http-header>Origin-Policy</a>: preferred="policy-2", allowed=("policy-1" <mark>null</mark>)
+  </pre>
+
+  This indicates that the [=null origin policy=] is acceptable, if both "<code>policy-1</code>" and "<code>policy-2</code>" are not cached, and thus allows responses to initial visitors to proceed without blocking on fetching an origin policy. But, because there is a <code>preferred</code> value, in such cases the browser will also do a non-blocking fetch to <code>https://example.com/.well-known/origin-policy</code>, to update the HTTP cache for any future requests to <code>https://example.com/</code>.
+
+  MegaCorp could even vary their `<a http-header><code>Origin-Policy</code></a>` header dynamically between this fast-but-permissive version and the previous blocking-and-strict version, depending on characteristics of the request such as [=credentials=].
+</div>
+
+<div class="example" id="example-latest">
+  MegaCorp is downsizing, and can no longer spare headcount for a dedicated Origin Policy Specialist to carefully maintain their origin policy manifest's "<code><a for="origin policy manifest">ids</a></code>" field, and their `<a http-header><code>Origin-Policy</code></a>` header <code>allowed</code> and <code>preferred</code> values. They just want to perform updates to their origin policy manifest, and have them rolled out to their visitors as soon as is possible.
+
+  To make this work, they change all their response headers to
+
+  <pre>
+  <a http-header>Origin-Policy</a>: preferred=latest-from-network, allowed=(latest null)
+  </pre>
+
+  which will ensure that browser uses the latest origin policy available from the cache, if any, or the [=null origin policy=], if nothing is cached. Furthermore, the <code>preferred=latest-from-network</code> part of the header ensures that the browser will always perform a non-blocking fetch to <code>https://example.com/.well-known/origin-policy</code> to update the HTTP cache.
+
+  This is slightly less efficient than the previous version. And, it doesn't allow expressing constraints on the contents of policies, by matching preferred and allowed values with the manifest's "<code><a for="origin policy manifest">ids</a></code>" field. But, it is simpler to maintain.
+</div>
+
 <div class="example" id="example-killswitch">
   MegaCorp wishes to remove the origin policy, and ensure that any visitors to its site no longer get any of its effects. It can do so by using the following `<a http-header><code>Origin-Policy</code></a>` response header:
 
@@ -267,7 +295,7 @@ This document introduces a new delivery mechanism for policies which are meant t
   <a http-header>Origin-Policy</a>: allowed=(null)
   </pre>
 
-  When the browser recieves this header, it will ensure that no origin policy is applied for the response, since only the [=null policy=] is allowed. It will also evict any cache entries for <code>https://example.com/.well-known/origin-policy</code>.
+  When the browser receives this header, it will ensure that no origin policy is applied for the response, since only the [=null policy=] is allowed.
 </div>
 
 </div>
@@ -280,14 +308,16 @@ The `<dfn http-header><code>Origin-Policy</code></dfn>` response [=header=] can 
 
 `<a http-header><code>Origin-Policy</code></a>` is a [=structured header/dictionary=] structured header. The dictionary has two keys: [[!STRUCTURED-HEADERS]]
 
-* <code>allowed</code>, whose value is an [=structured header/inner list=] that contains [=valid origin policy IDs=] as strings, or the token <code>null</code>, and
-* <code>preferred</code>, whose value is a [=valid origin policy ID=].
+* <code>allowed</code>, whose value is an [=structured header/inner list=] that contains [=valid origin policy IDs=] as strings, or the token <code>null</code>, or the token <code>latest</code>; and
+* <code>preferred</code>, whose value is either a [=valid origin policy ID=], or the token <code>latest-from-network</code>.
 
 At least one of these two entries needs to be provided for the header to have useful behavior.
 
+<p class="note">If an ID is provided for <code>preferred</code>, it is unnecessary to also include it in the <code>allowed</code> list.</p>
+
 No [=structured header/parameters=] are used in any locations within the structured header.
 
-The processing model for this header, including the fallback behavior for when it is not provided or does not conform to the above data model, is given in [[#from-response]]. In general, the fallback behavior for malformed headers is to behave the same as if `<code>Origin-Policy: allowed=(null)</code>` is sent, and thus use the [=null policy|null origin policy=] for processing the [=response=]. The processing model for omitting the header is to use any previously-cached [=/origin policy=] for the [=/origin=].
+The processing model for this header, including the fallback behavior for when it is not provided or does not conform to the above data model, is given in [[#from-response]]. In general, the fallback behavior for malformed headers is to behave the same as if `<code>Origin-Policy: allowed=(null)</code>` is sent, and thus use the [=null origin policy=] for processing the [=response=]. The processing model for omitting the header is to use any previously-cached [=/origin policy=] for the [=/origin=].
 
 <h3 id="manifest-file">The origin policy manifest</h3>
 
@@ -399,7 +429,7 @@ An <dfn>origin policy</dfn> is a [=struct=] containing the following [=struct/it
 : <dfn for="origin policy">content security policies</dfn>
 :: A [=list=] of [=content security policy object|content security policies=]. [[!CSP]]
 
-The <dfn>null policy</dfn> is an [=/origin policy=] whose [=origin policy/IDs=] is a list containing the single item null, and who has empty lists for its [=origin policy/feature policy=] and [=origin policy/content security policies=]. As enforced by the processing model, no other policy can have a null in its [=origin policy/IDs=] list.
+The <dfn lt="null policy|null origin policy">null policy</dfn> is an [=/origin policy=] whose [=origin policy/IDs=] is a list containing the single item null, and who has empty lists for its [=origin policy/feature policy=] and [=origin policy/content security policies=]. As enforced by the processing model, no other policy can have a null in its [=origin policy/IDs=] list.
 
 A [=/string=] is a <dfn>valid origin policy ID</dfn> if all of the following are true:
 
@@ -685,6 +715,7 @@ Thanks to
 Anne van Kesteren,
 Daniel Hausknecht,
 Daniel Vogelheim,
+Eric Portis,
 Jeffrey Yasskin, and
 Nihanth Subramanya
 for being awesome!

--- a/index.src.html
+++ b/index.src.html
@@ -465,7 +465,7 @@ This section details the entry point algorithms, for determining which origin po
     1. Let |rawAllowedList| be |parsedHeader|["<code>allowed</code>"][0].
     1. [=For each=] |itemTuple| in |rawAllowedList|:
       1. Let |allowedId| be |itemTuple|[0].
-      1. If |allowedId| is not a [=structured header/string=], the [=structured header/token=] <code>null</code>, or the [=structured header/token=] <code>latest</code>, then return "<code>unparseable</code>".
+      1. If |allowedId| is not a [=structured header/string=], the [=structured header/token=] <code>null</code>, or the [=structured header/token=] <code>latest</code>, or if |allowedId| is the empty string, then return "<code>unparseable</code>".
       1. If |allowedId| is the <code>null</code> [=structured header/token=], then set |allowedId| to null.
       1. If |allowedId| is the <code>latest</code> [=structured header/token=], then set |allowedId| to [=latest=].
       1. Assert: if |allowedId| is a string, then it is a [=valid origin policy ID=].

--- a/index.src.html
+++ b/index.src.html
@@ -438,6 +438,8 @@ A [=/string=] is a <dfn>valid origin policy ID</dfn> if all of the following are
 
 <h2 id="processing-model">Processing model</h2>
 
+The below algorithms make use of the special values <dfn>latest</dfn> and <dfn>latest-from-network</dfn>, which we use as the parsed representation of the corresponding [=structured header/tokens=] from the `<a http-header><code>Origin-Policy</code></a>` structured header.
+
 <h3 id="from-response">Response processing</h3>
 
 This section details the entry point algorithms, for determining which origin policy applies to an incoming [=response=].
@@ -450,7 +452,7 @@ This section details the entry point algorithms, for determining which origin po
   1. If |header| is null, then return "<code>success</code>".
   1. Let (|allowedIds|, |preferredId|) be the result of <a>parsing an `<code>Origin-Policy</code>` header</a> given |header|. If this instead returns "<code>unparseable</code>", then return "<code>success</code>".
   1. Let |origin| be |response|'s [=response/URL=]'s [=url/origin=].
-  1. Return the result of [=updating an origin's origin policy=] for |origin| given |client| and |allowedIds|. If |preferredId| is not null, pass it along too.
+  1. Return the result of [=updating an origin's origin policy=] for |origin| given |client|, |allowedIds|, and |preferredId|.
 </div>
 
 <div algorithm>
@@ -463,15 +465,17 @@ This section details the entry point algorithms, for determining which origin po
     1. Let |rawAllowedList| be |parsedHeader|["<code>allowed</code>"][0].
     1. [=For each=] |itemTuple| in |rawAllowedList|:
       1. Let |allowedId| be |itemTuple|[0].
-      1. If |allowedId| is not a [=structured header/string=] or the [=structured header/token=] <code>null</code>, then return "<code>unparseable</code>".
+      1. If |allowedId| is not a [=structured header/string=], the [=structured header/token=] <code>null</code>, or the [=structured header/token=] <code>latest</code>, then return "<code>unparseable</code>".
+      1. If |allowedId| is the <code>null</code> [=structured header/token=], then set |allowedId| to null.
+      1. If |allowedId| is the <code>latest</code> [=structured header/token=], then set |allowedId| to [=latest=].
       1. Assert: if |allowedId| is a string, then it is a [=valid origin policy ID=].
-      1. If |allowedId| is the <code>null</code> [=structured header/token=], then set |allowedId| to null. <span class="note">This is just a "type conversion" into our usual value space of Infra values. [[!INFRA]]</span>
       1. [=set/Append=] |allowedId| to |allowedIds|.
   1. Let |preferredId| be null.
   1. If |parsedHeader|["<code>preferred</code>"] [=map/exists=]:
     1. Set |preferredId| to |parsedHeader|["<code>preferred</code>"][0].
-    1. If |preferredId| is not a [=structured header/string=], or is the empty string, then return "<code>unparseable</code>".
-    1. Assert: |preferredId| is a [=valid origin policy ID=].
+    1. If |preferredId| is not a [=structured header/string=] or the [=structured header/token=] <code>latest-from-network</code>, or it is the empty string, then return "<code>unparseable</code>".
+    1. If |preferredId| is the <code>latest-from-network</code> [=structured header/token=], then set |preferredId| to [=latest-from-network=].
+    1. Assert: if |preferredId| is a string, then it is a [=valid origin policy ID=].
   1. Return the [=tuple=] (|allowedIds|, |preferredId|).
 
   <p class="note">The constant lookups of the 0th [=tuple/item=] in [=tuples=] above is due to the way that structured header parse results are generally packaged as tuples where the 0th item is the value of interest, and the 1st item is an associated [=ordered map=] of [=structured header/parameters=]. In all cases we ignore the parameters.</p>
@@ -480,24 +484,24 @@ This section details the entry point algorithms, for determining which origin po
 <h3 id="updating">Updating the origin policy</h3>
 
 <div algorithm>
-  To <dfn lt="update an origin's origin policy|updating an origin's origin policy">update an origin's origin policy</dfn> for an [=/origin=] |origin| given an [=environment settings object=] |client|, a [=list=] of strings |allowedIds| and an optional string |preferredId|:
+  To <dfn lt="update an origin's origin policy|updating an origin's origin policy">update an origin's origin policy</dfn> for an [=/origin=] |origin| given |client|, |allowedIds|, and |preferredId|:
 
   1. Let |cachedPolicy| be the result of [=retrieving the cached origin policy=] for |origin|.
-  1. If |preferredId| was given, and is [=list/contained=] in |cachedPolicy|'s [=origin policy/IDs=], then return "<code>success</code>".
-     <p class="note">Since |preferredId| is always a [=valid origin policy ID=], and in particular is not null, this step will never match if |cachedPolicy| is the [=null policy=].</p>
+  1. If |preferredId| is a string, and is [=list/contained=] in |cachedPolicy|'s [=origin policy/IDs=], then return "<code>success</code>".
   1. Let |url| be the result of [=getting the origin policy manifest URL=] for |origin|.
   1. If |url| is null, then return "<code>success</code>".
   1. Let |networkRequest| be a new [=request=] whose [=request/url=] is |url|, [=request/client=] is |client|, [=request/service-workers mode=] is "<code>none</code>", [=request/destination=] is "<code>manifest</code>", [=request/mode=] is "<code>same-origin</code>", [=request/redirect mode=] is "<code>error</code>", [=request/credentials mode=] is "<code>omit</code>", [=request/referrer policy=] is "<code>no-referrer</code>", and [=request/cache mode=] is "<code>no-cache</code>".
-  1. If any of |allowedIds| are [=list/contained=] in |cachedPolicy|'s [=origin policy/IDs=], then:
-    1. If |cachedPolicy| is the [=null policy=], or |preferredId| was provided, then [=in parallel=], [=fetch=] |networkRequest|. (This will update the cache, but the [=response=] will not be used.)
+  1. If |allowedIds| [=list/contains=] one of |cachedPolicy|'s [=origin policy/IDs=], or if |allowedIds| [=list/contains=] [=latest=], then:
+    1. If |cachedPolicy| is the [=null policy=], or |preferredId| is not null, then [=in parallel=], [=fetch=] |networkRequest|. (This will update the cache, but the [=response=] will not be used.)
     1. Return "<code>success</code>".
   1. If |allowedIds| contains null, then:
-    1. If |preferredId| was provided, then [=in parallel=], [=fetch=] |networkRequest|. (This will update the cache, but the [=response=] will not be used.)
+    1. If |preferredId| is not null, then [=in parallel=], [=fetch=] |networkRequest|. (This will update the cache, but the [=response=] will not be used.)
     1. Return "<code>success</code>".
   1. Let |networkResponse| be the result of [=fetching=] |networkRequest|. (Unlike the [=in parallel=] fetches, this is blocking.)
   1. Let |networkPolicy| be the result of [=getting an origin policy from a manifest response=] given |networkResponse|.
-  1. If either of the following is true:
-      * |preferredId| was given, and is [=list/contained=] in |networkPolicy|'s [=origin policy/IDs=]; or
+  1. If any of the following is true:
+      * |preferredId| is [=latest-from-network=]; or
+      * |preferredId| is a string, and is [=list/contained=] in |networkPolicy|'s [=origin policy/IDs=]; or
       * |allowedIds| [=list/contains=] one of |networkPolicy|'s [=origin policy/IDs=],
     then return "<code>success</code>".
   1. Return "<code>failure</code>".
@@ -513,9 +517,11 @@ This section details the entry point algorithms, for determining which origin po
         * |allowedIds| contains null: use the [=null policy=], and refresh the HTTP cache in the background.
         * |allowedIds| does not contain null: fetch |networkPolicy|, and use it if it matches |allowedIds| or |preferredId|.
       * |cachedPolicy| is not the [=null policy=]:
-        * |allowedIds| contains one of |cachedPolicy|'s [=origin policy/IDs=]: use |cachedPolicy|, and refresh the HTTP cache in the background if |preferredId| was provided.
-        * |allowedIds| does not contain any of |cachedPolicy|'s [=origin policy/IDs=] but does contain null: use the [=null policy=], and refresh the HTTP cache in the background if |preferredId| was provided.
-        * |allowedIds| contains neither any of |cachedPolicy|'s [=origin policy/IDs=] nor null: fetch |networkPolicy|, and use it if it matches |allowedIds| or |preferredId|.
+        * |allowedIds| matches one of |cachedPolicy|'s [=origin policy/IDs=]: use |cachedPolicy|, and refresh the HTTP cache in the background if |preferredId| was provided.
+        * |allowedIds| does not match any of |cachedPolicy|'s [=origin policy/IDs=] but does contain null: use the [=null policy=], and refresh the HTTP cache in the background if |preferredId| was provided.
+        * |allowedIds| does not match any of |cachedPolicy|'s [=origin policy/IDs=] and does not contain null: fetch |networkPolicy|, and use it if it matches |allowedIds| or |preferredId|.
+
+    Here [=latest=] always matches a non-[=null policy|null=] |cachedPolicy| and and [=latest-from-network=] always matches a fetched |networkPolicy|.
   </div>
 </div>
 

--- a/version-negotiation.md
+++ b/version-negotiation.md
@@ -32,7 +32,7 @@ Conceptually, origin policies are stored in the HTTP cache, under the URL `$orig
 
 A policy can have several identifiers, found in its JSON document as, for example, `"ids": ["policyA", "polB"]`.
 
-The `Origin-Policy` header can express that it allows, or prefers, specifically-identified policies. The header also can express that it allows any policy, with the token `lastest`, or no policy at all, with the token `null`. Finally, the header can express that it prefers the latest origin policy from the network, with the token `latest-from-network`.
+The `Origin-Policy` header can express that it allows, or prefers, specifically-identified policies. The header also can express that it allows any policy, with the token `lastest`, or that it allows no policy at all, with the token `null`. Finally, the header can express that it prefers the latest origin policy from the network, with the token `latest-from-network`.
 
 * ID-based matching is used when the web application wants to express constraints on the contents of the policy.
 * `latest` and `latest-from-network` are used when the web application wants to ensure there is an origin policy, but does not want to take on the maintenance burden of expressing ID-based constraints.


### PR DESCRIPTION
#67 points out that it can be useful to have values that require less maintenance from the site author. This adds the latest token for the allowed=() list, and the latest-from-network token for the preferred= entry, to allow such use cases.

In the process, this expands the README's illustration of the Origin-Policy header to contain more concrete examples, and removes the spec-sketch from version-negotiation.md in favor of a more broad outline.

This also clarifies that you do not need to duplicate the preferred value inside allowed.

Closes #67. Closes #61.

---

This doesn't yet have the processing model updated, but if you want to take a look @annevk and @eeeps at the README, examples, and updated header definition, your thoughts would be welcome. (Sorry for squishing both your issues into one PR, but they ended up feeling pretty related...)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/pull/72.html" title="Last updated on Feb 19, 2020, 4:04 PM UTC (7d023fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/72/6be0edf...7d023fe.html" title="Last updated on Feb 19, 2020, 4:04 PM UTC (7d023fe)">Diff</a>