### PR TITLE
Remove Vary header usage in examples

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -71,9 +71,6 @@ spec: CSP; type: dfn; urlPrefix: https://w3c.github.io/webappsec-csp/
 spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
   type: http-header
     text: Strict-Transport-Security; url: section-6.1
-spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
-  type: http-header
-    text: Vary; url: section-7.1.4
 </pre>
 
 <h2 id="intro">Introduction</h2>
@@ -128,7 +125,6 @@ This document introduces a new delivery mechanism for policies which are meant t
   Content-Type: text/html
   ...
   <a http-header>Origin-Policy</a>: allowed=("policy-1")
-  <a http-header>Vary</a>: origin-policy
   ...
   </pre>
 
@@ -230,7 +226,6 @@ This document introduces a new delivery mechanism for policies which are meant t
   Content-Type: text/html
   ...
   <a http-header>Origin-Policy</a>: allowed=("policy-1")
-  <a http-header>Vary</a>: origin-policy
   Cache-Control: max-age=31536000
   ...
   </pre>
@@ -722,6 +717,7 @@ Anne van Kesteren,
 Daniel Hausknecht,
 Daniel Vogelheim,
 Eric Portis,
-Jeffrey Yasskin, and
+Jeffrey Yasskin,
+Mark Nottingham, and
 Nihanth Subramanya
 for being awesome!


### PR DESCRIPTION
Origin-Policy is a response header, so Varying on it makes no sense. This was leftover from when Sec-Origin-Policy was a request header.

We may bring this back depending on #51, but for now it should be removed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/pull/79.html" title="Last updated on Feb 19, 2020, 4:11 PM UTC (e0e2d09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/79/3bd0206...e0e2d09.html" title="Last updated on Feb 19, 2020, 4:11 PM UTC (e0e2d09)">Diff</a>