### PR TITLE
Change the spec representation of the null policy

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -422,13 +422,13 @@ The processing model for how browsers send [=requests=] to this URL is given in 
 An <dfn>origin policy</dfn> is a [=struct=] containing the following [=struct/items=]:
 
 : <dfn for="origin policy">IDs</dfn>
-:: Either a [=list=] of [=/strings=] which are each a [=valid origin policy ID=], or a list containing the single item null.
+:: A [=list=] of [=/strings=] which are each a [=valid origin policy ID=].
 : <dfn for="origin policy">feature policy</dfn>
 :: A [=feature policy directive=]. [[!FEATURE-POLICY]]
 : <dfn for="origin policy">content security policies</dfn>
 :: A [=list=] of [=content security policy object|content security policies=]. [[!CSP]]
 
-The <dfn lt="null policy|null origin policy">null policy</dfn> is an [=/origin policy=] whose [=origin policy/IDs=] is a list containing the single item null, and who has empty lists for its [=origin policy/feature policy=] and [=origin policy/content security policies=]. As enforced by the processing model, no other policy can have a null in its [=origin policy/IDs=] list.
+The <dfn lt="null policy|null origin policy">null policy</dfn> is an [=/origin policy=] that has empty lists for its [=origin policy/IDs=], [=origin policy/feature policy=], and [=origin policy/content security policies=]. As enforced by the processing model, no other policy can an empty [=origin policy/IDs=] list.
 
 A [=/string=] is a <dfn>valid origin policy ID</dfn> if all of the following are true:
 
@@ -486,12 +486,12 @@ This section details the entry point algorithms, for determining which origin po
   To <dfn lt="fetch an origin's origin policy|fetching an origin's origin policy">fetch an origin's origin policy</dfn> for an [=/origin=] |origin| given |client|, |allowedIds|, and |preferredId|:
 
   1. Let |cachedPolicy| be the result of [=retrieving the cached origin policy=] given |origin| and |client|.
-  1. If |preferredId| is a string, and is [=list/contained=] in |cachedPolicy|'s [=origin policy/IDs=], then return |cachedPolicy|.
+  1. If |preferredId| is [=list/contained=] in |cachedPolicy|'s [=origin policy/IDs=], then return |cachedPolicy|.
   1. Let |url| be the result of [=getting the origin policy manifest URL=] for |origin|.
   1. If |url| is null, then return the [=null policy=].
   1. Let |networkRequest| be a new [=request=] whose [=request/url=] is |url|, [=request/client=] is |client|, [=request/service-workers mode=] is "<code>none</code>", [=request/destination=] is "<code>manifest</code>", [=request/mode=] is "<code>same-origin</code>", [=request/redirect mode=] is "<code>error</code>", [=request/credentials mode=] is "<code>omit</code>", [=request/referrer policy=] is "<code>no-referrer</code>", and [=request/cache mode=] is "<code>no-cache</code>".
-  1. If |allowedIds| [=list/contains=] one of |cachedPolicy|'s [=origin policy/IDs=], or if |allowedIds| [=list/contains=] [=latest=], then:
-    1. If |cachedPolicy| is the [=null policy=], or |preferredId| is not null, then [=in parallel=], [=fetch=] |networkRequest|. (This will update the cache, but the [=response=] will not be used.)
+  1. If |cachedPolicy| is not the [=null policy=], and either |allowedIds| [=list/contains=] one of |cachedPolicy|'s [=origin policy/IDs=], or |allowedIds| [=list/contains=] [=latest=], then:
+    1. If |preferredId| is not null, then [=in parallel=], [=fetch=] |networkRequest|. (This will update the cache, but the [=response=] will not be used.)
     1. Return |cachedPolicy|.
   1. If |allowedIds| contains null, then:
     1. If |preferredId| is not null, then [=in parallel=], [=fetch=] |networkRequest|. (This will update the cache, but the [=response=] will not be used.)


### PR DESCRIPTION
Previously it was represented as an origin policy whose IDs were the list containing the single item null. This was done because it was somewhat convenient for writing the algorithm in previous revisions of "fetch an origin's origin policy", i.e. we could compare allowedIds (which might contain a null from the header) with cachedPolicy's IDs (which might contain null if the cached policy was the null policy).

However, this was overly clever and confusing. It caused any algorithms involving ID comparison to need careful inspection to make sure they dealt with such an exceptional case. And, it gets in the way when you want to do things like reflect the origin policy IDs to JavaScript, per #48.

So instead, this commit moves to a model where the null origin policy has no IDs. With the current revision of "fetch an origin's origin policy", this seems to purely simplify things.

---

Will merge after CI signs off, but after-the-fact review is always appreciated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/pull/82.html" title="Last updated on Feb 25, 2020, 6:49 PM UTC (196e891)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/82/9a247f9...196e891.html" title="Last updated on Feb 25, 2020, 6:49 PM UTC (196e891)">Diff</a>