### PR TITLE
Add self.originPolicyIds

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -77,6 +77,38 @@ spec: RFC6797; urlPrefix: https://tools.ietf.org/html/rfc6797
     text: Strict-Transport-Security; url: section-6.1
 </pre>
 
+<style>
+/* domintro from https://resources.whatwg.org/standard.css */
+.domintro {
+  position: relative;
+  color: green;
+  background: #DDFFDD;
+  margin: 2.5em 0 2em 0;
+  padding: 1.5em 1em 0.5em 2em;
+}
+
+.domintro dt, .domintro dt * {
+  color: black;
+  font-size: inherit;
+}
+.domintro dd {
+  margin: 0.5em 0 1em 2em; padding: 0;
+}
+.domintro dd p {
+  margin: 0.5em 0;
+}
+.domintro::before {
+  content: 'For web developers (non-normative)';
+  background: green;
+  color: white;
+  padding: 0.15em 0.25em;
+  font-style: normal;
+  position: absolute;
+  top: -0.8em;
+  left: -0.8em;
+}
+</style>
+
 <h2 id="intro">Introduction</h2>
 
 <div nonnormative>
@@ -595,6 +627,67 @@ The <a spec="FETCH">main fetch</a> algorithm is modified by inserting the follow
 1. Let |originPolicy| be the result of [=getting the origin policy for a response=] given |internalResponse| and <var ignore>request</var>'s [=request/client=].
 1. If |originPolicy| is "<code>failure</code>", then set <var ignore>response</var> and |internalResponse| to a [=network error=].
 1. Otherwise, set |internalResponse|'s [=response/origin policy=] to |originPolicy|.
+
+<h3 id="monkeypatch-html">HTML</h3>
+
+Various parts of the HTML Standard need patching to support the {{WindowOrWorkerGlobalScope/originPolicyIds}} feature.
+
+<h4 id="monkeypatch-html-windoworworkerglobalscope"><code>WindowOrWorkerGlobalScope</code></h4>
+
+Every {{WindowOrWorkerGlobalScope}} object has an associated <dfn for="WindowOrWorkerGlobalScope">origin policy IDs</dfn>, which is a <code><a interface>FrozenArray</a>&lt;<a interface>DOMString</a>></code>. It is initially the result of [=create a frozen array|creating a frozen array=] from the empty [=list=].
+
+<pre class="idl">
+  partial interface mixin WindowOrWorkerGlobalScope {
+    readonly attribute FrozenArray&lt;DOMString> originPolicyIds;
+  };
+</pre>
+
+<dl class="domintro">
+  <dt><code>self . {{WindowOrWorkerGlobalScope/originPolicyIds}}</code>
+  <dd>
+    <p>Returns a frozen array containing the [=origin policy/IDs=] of the [=/origin policy=] that applies to the global object. These match the "<a for="origin policy manifest"><code>ids</code></a>" member from the [=origin policy manifest=] (omitting any values that are not [=valid origin policy IDs|valid=]). If the [=null origin policy=] is applied, then the array will be empty.</p>
+
+    <p>This can be especially useful in scenarios where the `<a http-header><code>Origin-Policy</code></a>` header allows multiple possible origin policies, or the [=null origin policy=], and the page wants a signal to determine which policy the browser retrieved.</p>
+  </dd>
+</dl>
+
+The <code><dfn attribute for="WindowOrWorkerGlobalScope">originPolicyIds</dfn></code> attribute's getter steps are to return [=this=]'s [=WindowOrWorkerGlobalScope/origin policy IDs=].
+
+<h4 id="monkeypatch-html-navigation">Navigation</h4>
+
+During [=navigate|navigation=], in particular in the <a spec="HTML">create and initialize a <code>Document</code> object</a> algorithm, we need to set the newly-created {{Window}}'s [=WindowOrWorkerGlobalScope/origin policy IDs=]. To do so, as the last substep of the "Otherwise" step that creates a new realm and Window, modify the existing last step to save the created [=environment settings object=] as <var ignore>settingsObject</var>, and then add the following step:
+
+1. Set <var ignore>settingsObject</var>'s [=environment settings object/global object=]'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=create a frozen array|creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
+
+<h4 id="monkeypatch-html-worker">Running a worker</h4>
+
+In the <a spec="HTML">run a worker</a> algorithm, we need to set the newly-created {{WorkerGlobalScope}}'s [=WindowOrWorkerGlobalScope/origin policy IDs=]. To do so, inside the <a spec="HTML">perform the fetch</a> steps, after step 2 (which calls [=fetch=]) insert the following step:
+
+1. Set <var ignore>worker global scope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=create a frozen array|creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
+
+<h3 id="monkeypatch-sw">Service Worker</h3>
+
+Various parts of the Service Worker specification need patching to support the {{WindowOrWorkerGlobalScope/originPolicyIds}} feature.
+
+<h4 id="monkeypatch-sw-model">Model</h4>
+
+Every [=/service worker=] gains an associated <dfn for="service worker">origin policy IDs</dfn>, which is a <code><a interface>FrozenArray</a>&lt;<a interface>DOMString</a>></code>.
+
+<h4 id="monkeypatch-sw-update">Update algorithm</h4>
+
+The <a spec="SERVICE-WORKERS">update</a> algorithm needs to save the [=/origin policy=] [=origin policy/IDs=] from the [=response=] onto the [=/service worker=]. To do so, insert the following step after step 1:
+
+1. Let <var ignore>origin policy IDs</var> be the result of [=create a frozen array|creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
+
+and then the following step after step 15:
+
+1. Set <var ignore>service worker</var>'s [=service worker/origin policy IDs=] to <var ignore>origin policy IDs</var>.
+
+<h4 id="monkeypatch-sw-run">Run service worker algorithm</h4>
+
+The <a spec="SERVICE-WORKERS">run service worker</a> algorithm needs to copy the [=service worker/origin policy IDs=] from the [=/service worker=] onto the {{ServiceWorkerGlobalScope}}. To do so, insert the following step after step 7.7:
+
+1. Set <var ignore>workerGlobalScope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to <var ignore>serviceWorker</var>'s [=service worker/origin policy IDs=].
 
 <h3 id="monkeypatch-fp">Feature Policy</h3>
 


### PR DESCRIPTION
Closes #48. /cc @Sora2455.

For now I went with the empty array for the null policy (so you detect the null policy with `self.originPolicyIds.length === 0`) but I could easily change it to null (`self.originPolicyIds === null`). Thoughts welcome.

/cc @jakearchibald for review on the service worker bits. I think I found the right place to plug things in, but it's not always obvious.

Note that per discussions currently in #81 the origin policy IDs will stay at its default (currently empty frozen array) for new browsing contexts in their initial `about:blank`, matching the fact that no origin policy is applied to them. So `window.open().originPolicyIds.length === 0`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/pull/83.html" title="Last updated on Feb 25, 2020, 6:57 PM UTC (c08a807)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/83/52ba467...c08a807.html" title="Last updated on Feb 25, 2020, 6:57 PM UTC (c08a807)">Diff</a>