### PR TITLE
Fix self.originPolicyIds creation for service workers

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -671,15 +671,19 @@ Various parts of the Service Worker specification need patching to support the {
 
 <h4 id="monkeypatch-sw-model">Model</h4>
 
-Every [=/service worker=] gains an associated <dfn for="service worker">origin policy IDs</dfn>, which is a <code><a interface>FrozenArray</a>&lt;<a interface>DOMString</a>></code>.
+Every [=/service worker=] gains an associated <dfn for="service worker">origin policy IDs</dfn>, which is a [=list=] of [=strings=].
 
 <h4 id="monkeypatch-sw-update">Update algorithm</h4>
 
-The <a spec="SERVICE-WORKERS">update</a> algorithm needs to save the [=/origin policy=] [=origin policy/IDs=] from the [=response=] onto the [=/service worker=]. To do so, insert the following step after step 1:
+The <a spec="SERVICE-WORKERS">update</a> algorithm needs to save the [=/origin policy=] [=origin policy/IDs=] from the [=response=] onto the [=/service worker=]. To do so, insert the following step after step 6:
 
-1. Let <var ignore>origin policy IDs</var> be the result of [=create a frozen array|creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
+1. Let <var ignore>origin policy IDs</var> be an empty [=list=].
 
-and then the following step after step 15:
+Then insert the following step after step 9's [=perform the fetch=] substep 9:
+
+1. Set <var ignore>origin policy IDs</var> to <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
+
+and finally add the following step after step 14:
 
 1. Set <var ignore>service worker</var>'s [=service worker/origin policy IDs=] to <var ignore>origin policy IDs</var>.
 
@@ -687,7 +691,7 @@ and then the following step after step 15:
 
 The <a spec="SERVICE-WORKERS">run service worker</a> algorithm needs to copy the [=service worker/origin policy IDs=] from the [=/service worker=] onto the {{ServiceWorkerGlobalScope}}. To do so, insert the following step after step 7.7:
 
-1. Set <var ignore>workerGlobalScope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to <var ignore>serviceWorker</var>'s [=service worker/origin policy IDs=].
+1. Set <var ignore>workerGlobalScope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=create a frozen array|creating a frozen array=] from <var ignore>serviceWorker</var>'s [=service worker/origin policy IDs=].
 
 <h3 id="monkeypatch-fp">Feature Policy</h3>
 
@@ -813,6 +817,7 @@ Anne van Kesteren,
 Daniel Hausknecht,
 Daniel Vogelheim,
 Eric Portis,
+Jake Archibald,
 Jeffrey Yasskin,
 Mark Nottingham, and
 Nihanth Subramanya

--- a/index.src.html
+++ b/index.src.html
@@ -634,7 +634,7 @@ Various parts of the HTML Standard need patching to support the {{WindowOrWorker
 
 <h4 id="monkeypatch-html-windoworworkerglobalscope"><code>WindowOrWorkerGlobalScope</code></h4>
 
-Every {{WindowOrWorkerGlobalScope}} object has an associated <dfn for="WindowOrWorkerGlobalScope">origin policy IDs</dfn>, which is a <code><a interface>FrozenArray</a>&lt;<a interface>DOMString</a>></code>. It is initially the result of [=create a frozen array|creating a frozen array=] from the empty [=list=].
+Every {{WindowOrWorkerGlobalScope}} object has an associated <dfn for="WindowOrWorkerGlobalScope">origin policy IDs</dfn>, which is a <code><a interface>FrozenArray</a>&lt;<a interface>DOMString</a>></code>. It is initially the result of [=creating a frozen array=] from the empty [=list=].
 
 <pre class="idl">
   partial interface mixin WindowOrWorkerGlobalScope {
@@ -657,13 +657,13 @@ The <code><dfn attribute for="WindowOrWorkerGlobalScope">originPolicyIds</dfn></
 
 During [=navigate|navigation=], in particular in the <a spec="HTML">create and initialize a <code>Document</code> object</a> algorithm, we need to set the newly-created {{Window}}'s [=WindowOrWorkerGlobalScope/origin policy IDs=]. To do so, as the last substep of the "Otherwise" step that creates a new realm and Window, modify the existing last step to save the created [=environment settings object=] as <var ignore>settingsObject</var>, and then add the following step:
 
-1. Set <var ignore>settingsObject</var>'s [=environment settings object/global object=]'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=create a frozen array|creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
+1. Set <var ignore>settingsObject</var>'s [=environment settings object/global object=]'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
 
 <h4 id="monkeypatch-html-worker">Running a worker</h4>
 
 In the <a spec="HTML">run a worker</a> algorithm, we need to set the newly-created {{WorkerGlobalScope}}'s [=WindowOrWorkerGlobalScope/origin policy IDs=]. To do so, inside the <a spec="HTML">perform the fetch</a> steps, after step 2 (which calls [=fetch=]) insert the following step:
 
-1. Set <var ignore>worker global scope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=create a frozen array|creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
+1. Set <var ignore>worker global scope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=creating a frozen array=] from <var ignore>response</var>'s [=response/origin policy=]'s [=origin policy/IDs=].
 
 <h3 id="monkeypatch-sw">Service Worker</h3>
 
@@ -691,7 +691,7 @@ and finally add the following step after step 14:
 
 The <a spec="SERVICE-WORKERS">run service worker</a> algorithm needs to copy the [=service worker/origin policy IDs=] from the [=/service worker=] onto the {{ServiceWorkerGlobalScope}}. To do so, insert the following step after step 7.7:
 
-1. Set <var ignore>workerGlobalScope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=create a frozen array|creating a frozen array=] from <var ignore>serviceWorker</var>'s [=service worker/origin policy IDs=].
+1. Set <var ignore>workerGlobalScope</var>'s [=WindowOrWorkerGlobalScope/origin policy IDs=] to the result of [=creating a frozen array=] from <var ignore>serviceWorker</var>'s [=service worker/origin policy IDs=].
 
 <h3 id="monkeypatch-fp">Feature Policy</h3>
 


### PR DESCRIPTION
This would previously create the FrozenArray<DOMString> in the main page realm (where the update algorithm was being called), not in the service worker realm. Also, the step references for the update algorithm were wrong.

This was pointed out in https://github.com/WICG/origin-policy/pull/83#discussion_r389532503.

@jakearchibald, thanks for finding this, and if you have time, a review would be appreciated!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/pull/90.html" title="Last updated on Mar 11, 2020, 2:27 PM UTC (3bbf585)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/origin-policy/90/f022f10...3bbf585.html" title="Last updated on Mar 11, 2020, 2:27 PM UTC (3bbf585)">Diff</a>